### PR TITLE
switch Lawson M/C with generic Q&A

### DIFF
--- a/assets/SCHEDULE.md
+++ b/assets/SCHEDULE.md
@@ -73,7 +73,7 @@ Rendering (to PDF):
 | 4:35 PM | 4:50 PM | PSH 350 | Oliver Beckstein | Master Class: Topology Attributes + DSSP |
 | 4:50 PM | 5:20 PM | PSH 350 | Irfan Alibay | Master Class: Intro to Contributing to MDAnalysis and MDAKits |
 | 5:20 PM | 5:35 PM | PSH 350 | Hugo MacDermott-Opeskin | Master Class: Fast Distance Calculations with Distopia in MDAnalysis |
-| 5:35 PM | 5:55 PM | PSH 350 | Lawson Woods | Master Class: MDAnalysis for ML/Protein Prediction Workflows |
+| 5:35 PM | 5:55 PM | PSH 350 | Core Developers | Master Class: Q&A |
 | 5:55 PM | 6:00 PM | PSH 350 | Irfan Alibay | Closing Remarks |
 
 \begin{center}


### PR DESCRIPTION
- Lawson does not have time to prepare master class: cancelled his
- replaced with a generic Q&A: audience can ask us anything and we try to come up with answers
- gives us a way to gauge interest/deman
- we can just end early


I also updated the spreadsheet [schedule UGM 2025 v4](https://docs.google.com/spreadsheets/d/1Y-AddwiZ3hWVYkK3ItjAbFktSlQm2nIA9P1OtZ96i1s/edit?gid=1184959919#gid=1184959919)